### PR TITLE
Fix for a NullpointerException and Bonds with negativ yields

### DIFF
--- a/jquantlib/src/main/java/org/jquantlib/daycounters/DayCounter.java
+++ b/jquantlib/src/main/java/org/jquantlib/daycounters/DayCounter.java
@@ -118,7 +118,7 @@ public class DayCounter {
      * @return the period between two dates as a fraction of year
      */
     public /*@Time*/ double yearFraction(final Date dateStart, final Date dateEnd) /* @ReadOnly */ {
-        return yearFraction(dateStart, dateEnd, null, null);
+        return yearFraction(dateStart, dateEnd, new Date(), new Date());
     }
 
 

--- a/jquantlib/src/main/java/org/jquantlib/instruments/Bond.java
+++ b/jquantlib/src/main/java/org/jquantlib/instruments/Bond.java
@@ -406,7 +406,7 @@ public class Bond extends Instrument {
                 dirtyPrice(),
                 dc, comp, freq,
                 settlementDate());
-        return solver.solve(objective, accuracy, 0.02, 0.0, 1.0);
+        return solver.solve(objective, accuracy, 0.02, -0.1, 1.0);
     }
 
     public/* @Rate */double yield(final DayCounter dc, 


### PR DESCRIPTION
This pull request fixes a NullPointerException ind DayCounter when using yearFraction with two Parameters

It also enables small negativ yields 
